### PR TITLE
Add markdown image toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Options:
   -e, --end INTEGER               Ending page number (0-based)
   -f, --formula BOOLEAN           Enable formula parsing (default: on, pipeline backend only)
   -t, --table BOOLEAN             Enable table parsing (default: on, pipeline backend only)
+  --md-image BOOLEAN             Embed images into markdown (default: on)
   -d, --device TEXT               Inference device (e.g., cpu/cuda/cuda:0/npu/mps, pipeline backend only)
   --vram INTEGER                  Maximum GPU VRAM usage per process (pipeline backend only)
   --source [huggingface|modelscope|local]

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -581,6 +581,7 @@ Options:
   -e, --end INTEGER               结束解析的页码（从 0 开始）
   -f, --formula BOOLEAN           是否启用公式解析（默认开启，仅 pipeline 后端）
   -t, --table BOOLEAN             是否启用表格解析（默认开启，仅 pipeline 后端）
+  --md-image BOOLEAN             是否在 Markdown 中嵌入图片（默认开启）
   -d, --device TEXT               推理设备（如 cpu/cuda/cuda:0/npu/mps，仅 pipeline 后端）
   --vram INTEGER                  单进程最大 GPU 显存占用（仅 pipeline 后端）
   --source [huggingface|modelscope|local]

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -36,6 +36,7 @@ def do_parse(
     f_dump_orig_pdf=True,  # Whether to dump original PDF files
     f_dump_content_list=True,  # Whether to dump content list files
     f_make_md_mode=MakeMode.MM_MD,  # The mode for making markdown content, default is MM_MD
+    f_md_image_enable=True,
     start_page_id=0,  # Start page ID for parsing, default is 0
     end_page_id=None,  # End page ID for parsing, default is None (parse all pages until the end of the document)
 ):
@@ -76,7 +77,7 @@ def do_parse(
 
             if f_dump_md:
                 image_dir = str(os.path.basename(local_image_dir))
-                md_content_str = pipeline_union_make(pdf_info, f_make_md_mode, image_dir)
+                md_content_str = pipeline_union_make(pdf_info, f_make_md_mode, image_dir, f_md_image_enable)
                 md_writer.write_string(
                     f"{pdf_file_name}.md",
                     md_content_str,
@@ -132,7 +133,7 @@ def do_parse(
 
             if f_dump_md:
                 image_dir = str(os.path.basename(local_image_dir))
-                md_content_str = vlm_union_make(pdf_info, f_make_md_mode, image_dir)
+                md_content_str = vlm_union_make(pdf_info, f_make_md_mode, image_dir, f_md_image_enable)
                 md_writer.write_string(
                     f"{pdf_file_name}.md",
                     md_content_str,
@@ -211,6 +212,7 @@ def parse_doc(
             backend=backend,
             parse_method=method,
             server_url=server_url,
+            f_md_image_enable=True,
             start_page_id=start_page_id,
             end_page_id=end_page_id
         )

--- a/mineru/backend/vlm/vlm_middle_json_mkcontent.py
+++ b/mineru/backend/vlm/vlm_middle_json_mkcontent.py
@@ -1,4 +1,4 @@
-from mineru.utils.config_reader import get_latex_delimiter_config
+from mineru.utils.config_reader import get_latex_delimiter_config, get_markdown_image_enable
 from mineru.utils.enum_class import MakeMode, BlockType, ContentType
 
 
@@ -39,7 +39,7 @@ def merge_para_with_text(para_block):
                     para_text += content
     return para_text
 
-def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path=''):
+def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path='', md_image_enable=True):
     page_markdown = []
     for para_block in para_blocks:
         para_text = ''
@@ -65,7 +65,7 @@ def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path=''):
                             for line in block['lines']:
                                 for span in line['spans']:
                                     if span['type'] == ContentType.IMAGE:
-                                        if span.get('image_path', ''):
+                                        if span.get('image_path', '') and md_image_enable:
                                             para_text += f"![]({img_buket_path}/{span['image_path']})"
                     for block in para_block['blocks']:  # 3rd.拼image_footnote
                         if block['type'] == BlockType.IMAGE_FOOTNOTE:
@@ -76,7 +76,7 @@ def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path=''):
                             for line in block['lines']:
                                 for span in line['spans']:
                                     if span['type'] == ContentType.IMAGE:
-                                        if span.get('image_path', ''):
+                                        if span.get('image_path', '') and md_image_enable:
                                             para_text += f"![]({img_buket_path}/{span['image_path']})"
                     for block in para_block['blocks']:  # 2nd.拼image_caption
                         if block['type'] == BlockType.IMAGE_CAPTION:
@@ -97,7 +97,7 @@ def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path=''):
                                     # if processed by table model
                                     if span.get('html', ''):
                                         para_text += f"\n{span['html']}\n"
-                                    elif span.get('image_path', ''):
+                                    elif span.get('image_path', '') and md_image_enable:
                                         para_text += f"![]({img_buket_path}/{span['image_path']})"
                 for block in para_block['blocks']:  # 3rd.拼table_footnote
                     if block['type'] == BlockType.TABLE_FOOTNOTE:
@@ -176,7 +176,9 @@ def make_blocks_to_content_list(para_block, img_buket_path, page_idx):
 def union_make(pdf_info_dict: list,
                make_mode: str,
                img_buket_path: str = '',
+               md_image_enable: bool = True,
                ):
+    md_image_enable = get_markdown_image_enable(md_image_enable)
     output_content = []
     for page_info in pdf_info_dict:
         paras_of_layout = page_info.get('para_blocks')
@@ -184,7 +186,7 @@ def union_make(pdf_info_dict: list,
         if not paras_of_layout:
             continue
         if make_mode in [MakeMode.MM_MD, MakeMode.NLP_MD]:
-            page_markdown = mk_blocks_to_markdown(paras_of_layout, make_mode, img_buket_path)
+            page_markdown = mk_blocks_to_markdown(paras_of_layout, make_mode, img_buket_path, md_image_enable)
             output_content.extend(page_markdown)
         elif make_mode == MakeMode.CONTENT_LIST:
             for para_block in paras_of_layout:

--- a/mineru/cli/client.py
+++ b/mineru/cli/client.py
@@ -111,6 +111,13 @@ from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
     default=True,
 )
 @click.option(
+    '--md-image',
+    'md_image_enable',
+    type=bool,
+    help='Embed images into markdown. Default is True.',
+    default=True,
+)
+@click.option(
     '-d',
     '--device',
     'device_mode',
@@ -136,7 +143,7 @@ from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
 )
 
 
-def main(input_path, output_dir, method, backend, lang, server_url, start_page_id, end_page_id, formula_enable, table_enable, device_mode, virtual_vram, model_source):
+def main(input_path, output_dir, method, backend, lang, server_url, start_page_id, end_page_id, formula_enable, table_enable, md_image_enable, device_mode, virtual_vram, model_source):
 
     if not backend.endswith('-client'):
         def get_device_mode() -> str:
@@ -182,6 +189,7 @@ def main(input_path, output_dir, method, backend, lang, server_url, start_page_i
                 p_formula_enable=formula_enable,
                 p_table_enable=table_enable,
                 server_url=server_url,
+                f_md_image_enable=md_image_enable,
                 start_page_id=start_page_id,
                 end_page_id=end_page_id
             )

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -91,6 +91,7 @@ def do_parse(
     f_dump_orig_pdf=True,
     f_dump_content_list=True,
     f_make_md_mode=MakeMode.MM_MD,
+    f_md_image_enable=True,
     start_page_id=0,
     end_page_id=None,
 ):
@@ -137,7 +138,7 @@ def do_parse(
 
             if f_dump_md:
                 image_dir = str(os.path.basename(local_image_dir))
-                md_content_str = pipeline_union_make(pdf_info, f_make_md_mode, image_dir)
+                md_content_str = pipeline_union_make(pdf_info, f_make_md_mode, image_dir, f_md_image_enable)
                 md_writer.write_string(
                     f"{pdf_file_name}.md",
                     md_content_str,
@@ -194,7 +195,7 @@ def do_parse(
 
             if f_dump_md:
                 image_dir = str(os.path.basename(local_image_dir))
-                md_content_str = vlm_union_make(pdf_info, f_make_md_mode, image_dir)
+                md_content_str = vlm_union_make(pdf_info, f_make_md_mode, image_dir, f_md_image_enable)
                 md_writer.write_string(
                     f"{pdf_file_name}.md",
                     md_content_str,

--- a/mineru/utils/config_reader.py
+++ b/mineru/utils/config_reader.py
@@ -102,6 +102,12 @@ def get_table_enable(table_enable):
     return table_enable
 
 
+def get_markdown_image_enable(md_image_enable):
+    md_image_enable_env = os.getenv('MINERU_MARKDOWN_IMAGE_ENABLE')
+    md_image_enable = md_image_enable if md_image_enable_env is None else md_image_enable_env.lower() == 'true'
+    return md_image_enable
+
+
 def get_latex_delimiter_config():
     config = read_config()
     if config is None:


### PR DESCRIPTION
## Summary
- add option `--md-image` to disable embedding images in markdown
- support env var `MINERU_MARKDOWN_IMAGE_ENABLE`
- propagate the new parameter through CLI and demo
- update markdown generation logic to respect the flag
- document the new option in README files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685a9b9139e8832080ef74f6bf159fa9